### PR TITLE
fixed requirements.txt conflict for pyqt5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-lxml==4.2.5
-PyQt5==5.11.3
-beautifulsoup4==4.6.3
+beautifulsoup4==4.12.2
+PyQt5==5.15.9


### PR DESCRIPTION
### Problem
I ran into a simple requirements version error within `requirements.txt` to do with `pyqt5` when installing this tool. I used `pipreqs` to resolve the problem, so I am opening a pull request with that solution.   
![image](https://github.com/MacroPolo/harshark/assets/16076573/0f8ff4cc-e6ac-4a20-9131-4c3b3137477a)


### Solution
I just used `pipreqs . --force` to resolve the dependencies again. 
![image](https://github.com/MacroPolo/harshark/assets/16076573/fae236d1-311d-4b35-9318-fadda4a1a04d)  
Worked like a charm.  

### Tested Platform  
Tested on Windows 10 with Python 3.10 via Windows PowerShell, GUI works as expected. Don't have time to test Mac or Linux at the moment, but WSL Ubuntu 22.04 seemed to like the fix -- however of course it had problems opening a viewport due to display manager stuff -- but that is par for the course.  